### PR TITLE
Feature/individual image add

### DIFF
--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -47,8 +47,8 @@ pub struct Document {
 pub struct Layer {
     name: String,
     image: Vec<u8>,
-    width: u16,
-    height: u16,
+    width: u32,
+    height: u32,
     #[allow(non_snake_case)]
     layerIdx: usize,
     visible: bool
@@ -62,8 +62,8 @@ fn split_to_layers(document: &psd::Psd) -> Vec<Layer> {
         .map(|(layer_idx, layer)| Layer {
             name: layer.name().to_owned(),
             image: layer.rgba().unwrap(),
-            width: layer.width(),
-            height: layer.height(),
+            width: document.width(),
+            height: document.height(),
             layerIdx: layer_idx,
             visible: true
         })

--- a/elm/Main.elm
+++ b/elm/Main.elm
@@ -34,7 +34,7 @@ subscriptions _ =
 -- PORTS
 
 
-port openPSDDocument : String -> Cmd a
+port openFile : String -> Cmd a
 
 
 port documentUpdated : (Json.Decode.Value -> msg) -> Sub msg
@@ -116,7 +116,7 @@ update msg model =
             ( { model | selectedFiles = files }, List.head files |> extractFile )
 
         SelectedFile file ->
-            ( { model | selectedFile = file }, openPSDDocument file )
+            ( { model | selectedFile = file }, openFile file )
 
         ActiveDocument document ->
             ( { model | activeDocument = document }, encodeAndRenderLayers document.layers )

--- a/elm/Main.elm
+++ b/elm/Main.elm
@@ -2,6 +2,7 @@ port module Main exposing (main)
 
 import Browser
 import Element exposing (Element, alignTop, centerY, column, el, html, htmlAttribute, padding, paddingXY, rgb255, row, spacing, text)
+import Element.Background as Background
 import Element.Border as Border
 import Element.Input as Input
 import Element.Region as Region
@@ -300,11 +301,7 @@ mapNewLayer layerJson =
         Ok layer ->
             NewLayer layer
 
-        Err error ->
-            let
-                _ =
-                    Debug.log "error: " error
-            in
+        Err _ ->
             NoOp
 
 
@@ -324,9 +321,13 @@ view model =
             [ elementRow model
             , row [ spacing 20, padding 20 ]
                 [ toolbar
-                , imageColumn model
+                , el
+                    [ Background.color (rgb255 128 128 128)
+                    , Element.width (Element.px 1280)
+                    , Element.height (Element.px 720)
+                    ]
+                    (imageColumn model)
                 , layerVisibilityColumn model
-                , html <| canvas [ id "test-canvas", width 500, height 500 ] []
                 ]
             ]
 
@@ -382,8 +383,8 @@ mapCanvasLayers layers =
             html <|
                 canvas
                     [ id element.name
-                    , width element.width
-                    , height element.height
+                    , width 1280
+                    , height 720
                     , style "position" "absolute"
                     , style "z-index" (String.fromInt element.layerIdx)
                     , style "left" "0"

--- a/reason/Elm.re
+++ b/reason/Elm.re
@@ -30,4 +30,7 @@ module Ports = {
 
   [@bs.send] [@bs.scope ("ports", "documentUpdated")]
   external documentUpdated: (app, Psd.document) => unit = "send";
+
+  [@bs.send] [@bs.scope ("ports", "addNewLayer")]
+  external addNewLayer: (app, Psd.layer) => unit = "send";
 };

--- a/reason/Elm.re
+++ b/reason/Elm.re
@@ -21,8 +21,8 @@ external init: elmInit => app = "";
 let newApp = init(elmInit(~node=getElementById(doc, "elm"), ~flags=apiUrl));
 
 module Ports = {
-  [@bs.send] [@bs.scope ("ports", "openPSDDocument")]
-  external openPSDDocument: (app, string => unit) => unit = "subscribe";
+  [@bs.send] [@bs.scope ("ports", "openFile")]
+  external openFile: (app, string => unit) => unit = "subscribe";
 
   [@bs.send] [@bs.scope ("ports", "renderLayers")]
   external renderLayers: (app, array(Psd.layer) => unit) => unit =

--- a/reason/Index.bs.js
+++ b/reason/Index.bs.js
@@ -19,11 +19,28 @@ function fillClampedArrayFromArray(inputArray, arrayBuffer) {
               }));
 }
 
-Elm$ReasonableRustyElm.newApp.ports.openPSDDocument.subscribe((function (imageUrl) {
-        var decodedString = atob(Caml_array.caml_array_get(imageUrl.split(","), 1));
-        var $$document = Psd$ReasonableRustyElm.parsePsd(fillArrayBufferFromString(decodedString, new Uint8Array(decodedString.length)));
-        Elm$ReasonableRustyElm.newApp.ports.documentUpdated.send($$document);
-        return /* () */0;
+function splitFileBodyAndHeader(fileUrl) {
+  var splitFile = fileUrl.split(",");
+  var fileType = Caml_array.caml_array_get(splitFile, 0).split(";");
+  return /* record */[
+          /* fileType */Caml_array.caml_array_get(fileType, 0),
+          /* fileContents */Caml_array.caml_array_get(splitFile, 1)
+        ];
+}
+
+Elm$ReasonableRustyElm.newApp.ports.openFile.subscribe((function (imageUrl) {
+        var parsedFile = splitFileBodyAndHeader(imageUrl);
+        if (parsedFile[/* fileType */0] === "data:image/vnd.adobe.photoshop") {
+          var decodedString = atob(parsedFile[/* fileContents */1]);
+          var $$document = Psd$ReasonableRustyElm.parsePsd(fillArrayBufferFromString(decodedString, new Uint8Array(decodedString.length)));
+          Elm$ReasonableRustyElm.newApp.ports.documentUpdated.send($$document);
+          return /* () */0;
+        } else {
+          return Curry._2(Render$ReasonableRustyElm.decodeImage, imageUrl, (function (imageData) {
+                        console.log(imageData);
+                        return /* () */0;
+                      }));
+        }
       }));
 
 Elm$ReasonableRustyElm.newApp.ports.renderLayers.subscribe((function (layers) {
@@ -41,6 +58,7 @@ Elm$ReasonableRustyElm.newApp.ports.renderLayers.subscribe((function (layers) {
 export {
   fillArrayBufferFromString ,
   fillClampedArrayFromArray ,
+  splitFileBodyAndHeader ,
   
 }
 /*  Not a pure module */

--- a/reason/Index.bs.js
+++ b/reason/Index.bs.js
@@ -36,8 +36,9 @@ Elm$ReasonableRustyElm.newApp.ports.openFile.subscribe((function (imageUrl) {
           Elm$ReasonableRustyElm.newApp.ports.documentUpdated.send($$document);
           return /* () */0;
         } else {
-          return Curry._2(Render$ReasonableRustyElm.decodeImage, imageUrl, (function (imageData) {
-                        console.log(imageData);
+          return Curry._2(Render$ReasonableRustyElm.decodeImage, imageUrl, (function (layer) {
+                        console.log(layer);
+                        Elm$ReasonableRustyElm.newApp.ports.addNewLayer.send(layer);
                         return /* () */0;
                       }));
         }
@@ -47,7 +48,7 @@ Elm$ReasonableRustyElm.newApp.ports.renderLayers.subscribe((function (layers) {
         $$Array.map((function (layer) {
                 if (layer.visible === true) {
                   var clampedArrayBuffer = fillClampedArrayFromArray(layer.image, new Uint8ClampedArray(layer.image.length));
-                  return Curry._2(Render$ReasonableRustyElm.renderPsd, layer.name, new ImageData(clampedArrayBuffer, 500, 500));
+                  return Curry._2(Render$ReasonableRustyElm.renderPsd, layer.name, new ImageData(clampedArrayBuffer, layer.width, layer.height));
                 } else {
                   return Curry._1(Render$ReasonableRustyElm.clearCanvas, layer.name);
                 }

--- a/reason/Index.re
+++ b/reason/Index.re
@@ -40,8 +40,12 @@ Elm.Ports.openFile(
         |> Psd.parsePsd;
       Elm.Ports.documentUpdated(Elm.newApp, document);
     } else {
-      Render.decodeImage(imageUrl, (imageData: Uint8ClampedArray.t) =>
-        Js.log(imageData)
+      Render.decodeImage(
+        imageUrl,
+        (layer: Psd.layer) => {
+          Js.log(layer);
+          Elm.Ports.addNewLayer(Elm.newApp, layer);
+        },
       );
     };
   },
@@ -62,8 +66,8 @@ Elm.Ports.renderLayers(
               layer##name,
               Webapi.Dom.Image.makeWithData(
                 ~array=clampedArrayBuffer,
-                ~width=Js.Int.toFloat(500),
-                ~height=Js.Int.toFloat(500),
+                ~width=Js.Int.toFloat(layer##width),
+                ~height=Js.Int.toFloat(layer##height),
               ),
             );
           } else {

--- a/reason/Index.re
+++ b/reason/Index.re
@@ -1,5 +1,10 @@
 open Js.Typed_array;
 
+type file = {
+  fileType: string,
+  fileContents: string,
+};
+
 let fillArrayBufferFromString =
     (decodedString: string, arrayBuffer: Uint8Array.t) => {
   Uint8Array.mapi(
@@ -13,19 +18,32 @@ let fillClampedArrayFromArray =
   Uint8ClampedArray.mapi((. _, index) => inputArray[index], arrayBuffer);
 };
 
-Elm.Ports.openPSDDocument(
+let splitFileBodyAndHeader = (fileUrl: string) => {
+  let splitFile = Js.String.split(",", fileUrl);
+  let fileType = splitFile->Array.get(0) |> Js.String.split(";");
+
+  {fileType: fileType->Array.get(0), fileContents: splitFile->Array.get(1)};
+};
+
+Elm.Ports.openFile(
   Elm.newApp,
   (imageUrl: string) => {
-    let decodedString =
-      Js.String.split(",", imageUrl)->Array.get(1) |> Webapi.Base64.atob;
+    let parsedFile = splitFileBodyAndHeader(imageUrl);
 
-    let document =
-      Js.String.length(decodedString)
-      |> Uint8Array.fromLength
-      |> fillArrayBufferFromString(decodedString)
-      |> Psd.parsePsd;
+    if (parsedFile.fileType == "data:image/vnd.adobe.photoshop") {
+      let decodedString = parsedFile.fileContents |> Webapi.Base64.atob;
 
-    Elm.Ports.documentUpdated(Elm.newApp, document);
+      let document =
+        Js.String.length(decodedString)
+        |> Uint8Array.fromLength
+        |> fillArrayBufferFromString(decodedString)
+        |> Psd.parsePsd;
+      Elm.Ports.documentUpdated(Elm.newApp, document);
+    } else {
+      Render.decodeImage(imageUrl, (imageData: Uint8ClampedArray.t) =>
+        Js.log(imageData)
+      );
+    };
   },
 );
 

--- a/reason/Index.re
+++ b/reason/Index.re
@@ -40,12 +40,8 @@ Elm.Ports.openFile(
         |> Psd.parsePsd;
       Elm.Ports.documentUpdated(Elm.newApp, document);
     } else {
-      Render.decodeImage(
-        imageUrl,
-        (layer: Psd.layer) => {
-          Js.log(layer);
-          Elm.Ports.addNewLayer(Elm.newApp, layer);
-        },
+      Render.decodeImage(imageUrl, (layer: Psd.layer) =>
+        Elm.Ports.addNewLayer(Elm.newApp, layer)
       );
     };
   },

--- a/reason/Render.bs.js
+++ b/reason/Render.bs.js
@@ -30,11 +30,27 @@ var getActiveFile = ((id) => {
         return canvas.toDataURL();
     });
 
+var decodeImage = ((dataUrl, cb) => {
+        const image = new Image();
+        image.src = dataUrl;
+
+        const canvas = new OffscreenCanvas(image.width, image.height);
+        const ctx = canvas.getContext('2d');
+
+        image.decode()
+            .then(() => {
+                 ctx.drawImage(image, 0, 0);
+                 const imageData = ctx.getImageData(0, 0, image.width, image.height);
+                 cb(imageData);
+            });
+    });
+
 export {
   renderImageWithDataUrl ,
   renderPsd ,
   clearCanvas ,
   getActiveFile ,
+  decodeImage ,
   
 }
 /* renderImageWithDataUrl Not a pure module */

--- a/reason/Render.bs.js
+++ b/reason/Render.bs.js
@@ -35,15 +35,14 @@ var decodeImage = ((dataUrl, cb) => {
         image.src = dataUrl;
 
         const canvas = document.createElement('canvas');
-        canvas.width = '500';
-        canvas.height = '500';
+        canvas.width = '1280';
+        canvas.height = '720';
         const ctx = canvas.getContext('2d');
 
         image.onload = () => {
              ctx.drawImage(image, 0, 0);
-             const imageData = ctx.getImageData(0, 0, 500, 500);
-             console.log(imageData);
-             cb({ name: "newImage", image: Array.from(imageData.data), width: 500, height: 500, layerIdx: 2, visible: true});
+             const imageData = ctx.getImageData(0, 0, 1280, 720);
+             cb({ name: "newImage", image: Array.from(imageData.data), width: 1280, height: 720, layerIdx: 2, visible: true});
         }
     });
 

--- a/reason/Render.bs.js
+++ b/reason/Render.bs.js
@@ -34,15 +34,17 @@ var decodeImage = ((dataUrl, cb) => {
         const image = new Image();
         image.src = dataUrl;
 
-        const canvas = new OffscreenCanvas(image.width, image.height);
+        const canvas = document.createElement('canvas');
+        canvas.width = '500';
+        canvas.height = '500';
         const ctx = canvas.getContext('2d');
 
-        image.decode()
-            .then(() => {
-                 ctx.drawImage(image, 0, 0);
-                 const imageData = ctx.getImageData(0, 0, image.width, image.height);
-                 cb(imageData);
-            });
+        image.onload = () => {
+             ctx.drawImage(image, 0, 0);
+             const imageData = ctx.getImageData(0, 0, 500, 500);
+             console.log(imageData);
+             cb({ name: "newImage", image: Array.from(imageData.data), width: 500, height: 500, layerIdx: 2, visible: true});
+        }
     });
 
 export {

--- a/reason/Render.re
+++ b/reason/Render.re
@@ -34,3 +34,20 @@ let getActiveFile: string => string = [%raw
         return canvas.toDataURL();
     }|}
 ];
+
+let decodeImage: (string, Js.Typed_array.Uint8ClampedArray.t => unit) => unit = [%raw
+  {|(dataUrl, cb) => {
+        const image = new Image();
+        image.src = dataUrl;
+
+        const canvas = new OffscreenCanvas(image.width, image.height);
+        const ctx = canvas.getContext('2d');
+
+        image.decode()
+            .then(() => {
+                 ctx.drawImage(image, 0, 0);
+                 const imageData = ctx.getImageData(0, 0, image.width, image.height);
+                 cb(imageData);
+            });
+    }|}
+];

--- a/reason/Render.re
+++ b/reason/Render.re
@@ -41,15 +41,14 @@ let decodeImage: (string, Psd.layer => unit) => unit = [%raw
         image.src = dataUrl;
 
         const canvas = document.createElement('canvas');
-        canvas.width = '500';
-        canvas.height = '500';
+        canvas.width = '1280';
+        canvas.height = '720';
         const ctx = canvas.getContext('2d');
 
         image.onload = () => {
              ctx.drawImage(image, 0, 0);
-             const imageData = ctx.getImageData(0, 0, 500, 500);
-             console.log(imageData);
-             cb({ name: "newImage", image: Array.from(imageData.data), width: 500, height: 500, layerIdx: 2, visible: true});
+             const imageData = ctx.getImageData(0, 0, 1280, 720);
+             cb({ name: "newImage", image: Array.from(imageData.data), width: 1280, height: 720, layerIdx: 2, visible: true});
         }
     }|}
 ];

--- a/reason/Render.re
+++ b/reason/Render.re
@@ -35,19 +35,21 @@ let getActiveFile: string => string = [%raw
     }|}
 ];
 
-let decodeImage: (string, Js.Typed_array.Uint8ClampedArray.t => unit) => unit = [%raw
+let decodeImage: (string, Psd.layer => unit) => unit = [%raw
   {|(dataUrl, cb) => {
         const image = new Image();
         image.src = dataUrl;
 
-        const canvas = new OffscreenCanvas(image.width, image.height);
+        const canvas = document.createElement('canvas');
+        canvas.width = '500';
+        canvas.height = '500';
         const ctx = canvas.getContext('2d');
 
-        image.decode()
-            .then(() => {
-                 ctx.drawImage(image, 0, 0);
-                 const imageData = ctx.getImageData(0, 0, image.width, image.height);
-                 cb(imageData);
-            });
+        image.onload = () => {
+             ctx.drawImage(image, 0, 0);
+             const imageData = ctx.getImageData(0, 0, 500, 500);
+             console.log(imageData);
+             cb({ name: "newImage", image: Array.from(imageData.data), width: 500, height: 500, layerIdx: 2, visible: true});
+        }
     }|}
 ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,11 +5,11 @@ const dist = path.resolve(__dirname, "dist");
 const webpack = require("webpack");
 require("dotenv").config();
 
-const PRODUCTION = process.env.NODE_ENV === 'production';
+const IS_PRODUCTION = process.env.NODE_ENV === 'production';
 
 module.exports = {
   entry: "./js/bootstrap.js",
-  mode: (PRODUCTION) ? 'production' : 'development',
+  mode: (IS_PRODUCTION) ? 'production' : 'development',
   output: {
     path: dist,
     filename: "bundle.js"
@@ -30,7 +30,7 @@ module.exports = {
     new WasmPackPlugin({
       crateDirectory: path.resolve(__dirname, "crate"),
       // WasmPackPlugin defaults to compiling in "dev" profile. To change that, use forceMode: 'release':
-      forceMode: (PRODUCTION) ? 'release' : ''
+      forceMode: (IS_PRODUCTION) ? 'release' : ''
     }),
 
     new webpack.EnvironmentPlugin(["API_URL"])
@@ -43,7 +43,7 @@ module.exports = {
         loader: 'elm-webpack-loader',
         options: {
           debug: false,
-          optimize: PRODUCTION
+          optimize: IS_PRODUCTION
         }
       }
     ]


### PR DESCRIPTION
Closes #3 

This PR gives the ability to open PNG and JPEG images along with the PSD documents we can already load. Images are opened via the Elm file module and then their data urls are sent to the ReasonML code to be decoded and added to the underlying document in a new layer.

For now new images will always be added as a new layer to the document.